### PR TITLE
Add type hints to models, db_utils, and utils

### DIFF
--- a/services/data/db_utils.py
+++ b/services/data/db_utils.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import List, Dict, Any, Tuple, Union
+from typing import List, Dict, Any, Optional, Tuple, Union
 import psycopg2
 import collections
 import datetime
@@ -70,13 +70,13 @@ def translate_task_key(v: str) -> Tuple[str, str]:
     return "task_id" if value.isnumeric() else "task_name", value
 
 
-def get_exposed_run_id(run_number: int, run_id: Union[str, None]) -> Union[str, int]:
+def get_exposed_run_id(run_number: Optional[int], run_id: Optional[str]) -> Union[str, int, None]:
     if run_id is not None:
         return run_id
     return run_number
 
 
-def get_exposed_task_id(task_id: int, task_name: Union[str, None]) -> Union[str, int]:
+def get_exposed_task_id(task_id: Optional[int], task_name: Optional[str]) -> Union[str, int, None]:
     if task_name is not None:
         return task_name
     return task_id

--- a/services/data/db_utils.py
+++ b/services/data/db_utils.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple, Union
 import psycopg2
 import collections
 import datetime
@@ -12,7 +12,7 @@ DBResponse = collections.namedtuple("DBResponse", "response_code body")
 DBPagination = collections.namedtuple("DBPagination", "limit offset count page")
 
 
-def aiopg_exception_handling(exception):
+def aiopg_exception_handling(exception: Exception) -> DBResponse:
     err_msg = str(exception)
     body = {"err_msg": err_msg}
     if isinstance(exception, asyncio.TimeoutError):
@@ -52,37 +52,37 @@ def aiopg_exception_handling(exception):
         return DBResponse(response_code=500, body=json.dumps(body))
 
 
-def get_db_ts_epoch_str():
+def get_db_ts_epoch_str() -> str:
     return str(int(round(time.time() * 1000)))
 
 
-def new_heartbeat_ts():
+def new_heartbeat_ts() -> int:
     return int(datetime.datetime.utcnow().timestamp())
 
 
-def translate_run_key(v: str):
+def translate_run_key(v: str) -> Tuple[str, str]:
     value = str(v)
     return "run_number" if value.isnumeric() else "run_id", value
 
 
-def translate_task_key(v: str):
+def translate_task_key(v: str) -> Tuple[str, str]:
     value = str(v)
     return "task_id" if value.isnumeric() else "task_name", value
 
 
-def get_exposed_run_id(run_number, run_id):
+def get_exposed_run_id(run_number: int, run_id: Union[str, None]) -> Union[str, int]:
     if run_id is not None:
         return run_id
     return run_number
 
 
-def get_exposed_task_id(task_id, task_name):
+def get_exposed_task_id(task_id: int, task_name: Union[str, None]) -> Union[str, int]:
     if task_name is not None:
         return task_name
     return task_id
 
 
-def get_latest_attempt_id_for_tasks(artifacts):
+def get_latest_attempt_id_for_tasks(artifacts: List[Dict[str, Any]]) -> Dict[str, int]:
     attempt_ids = {}
     for artifact in artifacts:
         attempt_ids[artifact["task_id"]] = max(

--- a/services/data/models.py
+++ b/services/data/models.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from .db_utils import get_exposed_run_id, get_exposed_task_id
 

--- a/services/data/models.py
+++ b/services/data/models.py
@@ -1,13 +1,24 @@
 import time
+from typing import Any, Dict, List, Optional, Union
+
 from .db_utils import get_exposed_run_id, get_exposed_task_id
 
 
 class FlowRow(object):
-    flow_id: str = None
-    user_name: str = None
-    ts_epoch: int = 0
+    flow_id: str
+    user_name: str
+    ts_epoch: int
+    tags: Optional[List[str]]
+    system_tags: Optional[List[str]]
 
-    def __init__(self, flow_id, user_name, ts_epoch=None, tags=None, system_tags=None):
+    def __init__(
+        self,
+        flow_id: str,
+        user_name: str,
+        ts_epoch: Optional[int] = None,
+        tags: Optional[List[str]] = None,
+        system_tags: Optional[List[str]] = None,
+    ) -> None:
         self.flow_id = flow_id
         self.user_name = user_name
         if ts_epoch is None:
@@ -16,7 +27,7 @@ class FlowRow(object):
         self.tags = tags
         self.system_tags = system_tags
 
-    def serialize(self, expanded: bool = False):
+    def serialize(self, expanded: bool = False) -> Dict[str, Any]:
         return {
             "flow_id": self.flow_id,
             "user_name": self.user_name,
@@ -27,23 +38,26 @@ class FlowRow(object):
 
 
 class RunRow(object):
-    flow_id: str = None
-    run_number: int = None
-    run_id: str = None
-    user_name: str = None
-    ts_epoch: int = 0
+    flow_id: str
+    run_number: Optional[int]
+    run_id: Optional[str]
+    user_name: str
+    ts_epoch: int
+    tags: Optional[List[str]]
+    system_tags: Optional[List[str]]
+    last_heartbeat_ts: Optional[int]
 
     def __init__(
         self,
-        flow_id,
-        user_name,
-        run_number=None,
-        run_id=None,
-        ts_epoch=None,
-        tags=None,
-        system_tags=None,
-        last_heartbeat_ts=None,
-    ):
+        flow_id: str,
+        user_name: str,
+        run_number: Optional[int] = None,
+        run_id: Optional[str] = None,
+        ts_epoch: Optional[int] = None,
+        tags: Optional[List[str]] = None,
+        system_tags: Optional[List[str]] = None,
+        last_heartbeat_ts: Optional[int] = None,
+    ) -> None:
         self.flow_id = flow_id
         self.user_name = user_name
         self.run_number = run_number
@@ -56,7 +70,7 @@ class RunRow(object):
         self.ts_epoch = ts_epoch
         self.last_heartbeat_ts = last_heartbeat_ts
 
-    def serialize(self, expanded: bool = False):
+    def serialize(self, expanded: bool = False) -> Dict[str, Any]:
         if expanded:
             return {
                 "flow_id": self.flow_id,
@@ -81,26 +95,26 @@ class RunRow(object):
 
 
 class StepRow(object):
-    flow_id: str = None
-    run_number: int = None
-    run_id: str = None
-    step_name: str = None
-    user_name: str = None
-    ts_epoch: int = 0
-    tags = None
-    system_tags = None
+    flow_id: str
+    run_number: int
+    run_id: Optional[str]
+    step_name: str
+    user_name: str
+    ts_epoch: int
+    tags: Optional[List[str]]
+    system_tags: Optional[List[str]]
 
     def __init__(
         self,
-        flow_id,
-        run_number,
-        run_id,
-        user_name,
-        step_name,
-        ts_epoch=None,
-        tags=None,
-        system_tags=None,
-    ):
+        flow_id: str,
+        run_number: int,
+        run_id: Optional[str],
+        user_name: str,
+        step_name: str,
+        ts_epoch: Optional[int] = None,
+        tags: Optional[List[str]] = None,
+        system_tags: Optional[List[str]] = None,
+    ) -> None:
         self.flow_id = flow_id
         self.run_number = run_number
 
@@ -117,7 +131,7 @@ class StepRow(object):
         self.tags = tags
         self.system_tags = system_tags
 
-    def serialize(self, expanded: bool = False):
+    def serialize(self, expanded: bool = False) -> Dict[str, Any]:
         if expanded:
             return {
                 "flow_id": self.flow_id,
@@ -142,31 +156,32 @@ class StepRow(object):
 
 
 class TaskRow(object):
-    flow_id: str = None
-    run_number: int = None
-    run_id: str = None
-    step_name: str = None
-    task_id: int = None
-    task_name: str = None
-    user_name: str = None
-    ts_epoch: int = 0
-    tags = None
-    system_tags = None
+    flow_id: str
+    run_number: int
+    run_id: Optional[str]
+    step_name: str
+    task_id: Optional[int]
+    task_name: Optional[str]
+    user_name: str
+    ts_epoch: int
+    tags: Optional[List[str]]
+    system_tags: Optional[List[str]]
+    last_heartbeat_ts: Optional[int]
 
     def __init__(
         self,
-        flow_id,
-        run_number,
-        run_id,
-        user_name,
-        step_name,
-        task_id=None,
-        task_name=None,
-        ts_epoch=None,
-        tags=None,
-        system_tags=None,
-        last_heartbeat_ts=None,
-    ):
+        flow_id: str,
+        run_number: int,
+        run_id: Optional[str],
+        user_name: str,
+        step_name: str,
+        task_id: Optional[int] = None,
+        task_name: Optional[str] = None,
+        ts_epoch: Optional[int] = None,
+        tags: Optional[List[str]] = None,
+        system_tags: Optional[List[str]] = None,
+        last_heartbeat_ts: Optional[int] = None,
+    ) -> None:
         self.flow_id = flow_id
         self.run_number = run_number
         self.run_id = run_id
@@ -182,7 +197,7 @@ class TaskRow(object):
         self.system_tags = system_tags
         self.last_heartbeat_ts = last_heartbeat_ts
 
-    def serialize(self, expanded: bool = False):
+    def serialize(self, expanded: bool = False) -> Dict[str, Any]:
         if expanded:
             return {
                 "flow_id": self.flow_id,
@@ -212,38 +227,38 @@ class TaskRow(object):
 
 
 class MetadataRow(object):
-    flow_id: str = None
-    run_number: int = None
-    run_id: str = None
-    step_name: str = None
-    task_id: int = None
-    task_name: str = None
-    id: int = None  # autoincrement
-    field_name: str = None
-    value: dict = None
-    type: str = None
-    user_name: str = None
-    ts_epoch: int = 0
-    tags = None
-    system_tags = None
+    flow_id: str
+    run_number: int
+    run_id: Optional[str]
+    step_name: str
+    task_id: int
+    task_name: Optional[str]
+    id: int
+    field_name: str
+    value: str
+    type: str
+    user_name: str
+    ts_epoch: int
+    tags: Optional[List[str]]
+    system_tags: Optional[List[str]]
 
     def __init__(
         self,
-        flow_id,
-        run_number,
-        run_id,
-        step_name,
-        task_id,
-        task_name,
-        id,
-        field_name,
-        value,
-        type,
-        user_name,
-        ts_epoch=None,
-        tags=None,
-        system_tags=None,
-    ):
+        flow_id: str,
+        run_number: int,
+        run_id: Optional[str],
+        step_name: str,
+        task_id: int,
+        task_name: Optional[str],
+        id: int,
+        field_name: str,
+        value: str,
+        type: str,
+        user_name: str,
+        ts_epoch: Optional[int] = None,
+        tags: Optional[List[str]] = None,
+        system_tags: Optional[List[str]] = None,
+    ) -> None:
         self.flow_id = flow_id
         self.run_number = run_number
         self.run_id = run_id
@@ -262,7 +277,7 @@ class MetadataRow(object):
         self.tags = tags
         self.system_tags = system_tags
 
-    def serialize(self, expanded: bool = False):
+    def serialize(self, expanded: bool = False) -> Dict[str, Any]:
         return {
             "id": self.id,
             "flow_id": self.flow_id,
@@ -280,41 +295,44 @@ class MetadataRow(object):
 
 
 class ArtifactRow(object):
-    flow_id: str = None
-    run_number: int = None
-    run_id: str = None
-    step_name: str = None
-    task_id: int = None
-    task_name: str = None
-    name: str = None
-    location: str = None
-    sha: str = None
-    type: str = None
-    content_type: str = None
-    user_name: str = None
-    attempt_id: int = 0
-    ts_epoch: int = 0
+    flow_id: str
+    run_number: int
+    run_id: Optional[str]
+    step_name: str
+    task_id: int
+    task_name: Optional[str]
+    name: str
+    location: str
+    ds_type: str
+    sha: Optional[str]
+    type: Optional[str]
+    content_type: Optional[str]
+    user_name: str
+    attempt_id: int
+    ts_epoch: int
+    tags: Optional[List[str]]
+    system_tags: Optional[List[str]]
 
     def __init__(
         self,
-        flow_id,
-        run_number,
-        run_id,
-        step_name,
-        task_id,
-        task_name,
-        name,
-        location,
-        ds_type,
-        sha,
-        type,
-        content_type,
-        user_name,
-        attempt_id,
-        ts_epoch=None,
-        tags=None,
-        system_tags=None,
-    ):
+        flow_id: str,
+        run_number: int,
+        run_id: Optional[str],
+        step_name: str,
+        task_id: int,
+        task_name: Optional[str],
+        name: str,
+        location: str,
+        ds_type: str,
+        sha: Optional[str],
+        type: Optional[str],
+        content_type: Optional[str],
+        user_name: str,
+        attempt_id: int,
+        ts_epoch: Optional[int] = None,
+        tags: Optional[List[str]] = None,
+        system_tags: Optional[List[str]] = None,
+    ) -> None:
         self.flow_id = flow_id
         self.run_number = run_number
         self.run_id = run_id
@@ -336,7 +354,7 @@ class ArtifactRow(object):
         self.tags = tags
         self.system_tags = system_tags
 
-    def serialize(self, expanded: bool = False):
+    def serialize(self, expanded: bool = False) -> Dict[str, Any]:
         return {
             "flow_id": self.flow_id,
             "run_number": get_exposed_run_id(self.run_number, self.run_id),

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -7,7 +7,7 @@ from multidict import MultiDict
 from urllib.parse import urlencode, quote
 from aiohttp import web
 from functools import wraps
-from typing import Dict
+from typing import Any, Callable, Dict, List, Optional
 import logging
 import psycopg2
 from distutils.version import LooseVersion
@@ -31,7 +31,7 @@ logging.basicConfig(level=log_level)
 ORIGIN_TO_ALLOW_CORS_FROM = os.environ.get('ORIGIN_TO_ALLOW_CORS_FROM', None)
 
 
-async def read_body(request_content):
+async def read_body(request_content: web.StreamResponse) -> Any:
     byte_array = bytearray()
     while not request_content.at_eof():
         data = await request_content.read(4)
@@ -40,7 +40,7 @@ async def read_body(request_content):
     return json.loads(byte_array.decode("utf-8"))
 
 
-def get_traceback_str():
+def get_traceback_str() -> str:
     """Get the traceback as a string."""
 
     exc_info = sys.exc_info()
@@ -57,7 +57,7 @@ def get_traceback_str():
     )
 
 
-def http_500(msg, id, traceback_str=get_traceback_str()):
+def http_500(msg: str, id: Optional[str], traceback_str: str = get_traceback_str()) -> web.Response:
     # NOTE: worth considering if we want to expose tracebacks in the future in the api messages.
     body = {
         'id': id,
@@ -71,7 +71,7 @@ def http_500(msg, id, traceback_str=get_traceback_str()):
     return web_response(500, body)
 
 
-def handle_exceptions(func):
+def handle_exceptions(func: Callable) -> Callable:
     """Catch exceptions and return appropriate HTTP error."""
 
     @wraps(func)
@@ -92,7 +92,7 @@ def handle_exceptions(func):
     return wrapper
 
 
-def format_response(func):
+def format_response(func: Callable) -> Callable:
     """handle formatting"""
 
     @wraps(func)
@@ -106,7 +106,7 @@ def format_response(func):
     return wrapper
 
 
-def web_response(status: int, body):
+def web_response(status: int, body: Any) -> web.Response:
     headers = MultiDict(
         {"Content-Type": "application/json",
          METADATA_SERVICE_HEADER: METADATA_SERVICE_VERSION})
@@ -122,7 +122,7 @@ def web_response(status: int, body):
                         headers=headers)
 
 
-def format_qs(query: Dict[str, str], overwrite=None):
+def format_qs(query: Dict[str, str], overwrite: Optional[Dict[str, str]] = None) -> str:
     q = dict(query)
     if overwrite:
         for key in overwrite:
@@ -131,7 +131,7 @@ def format_qs(query: Dict[str, str], overwrite=None):
     return ("?" if len(qs) > 0 else "") + qs
 
 
-def format_baseurl(request: web.BaseRequest):
+def format_baseurl(request: web.BaseRequest) -> str:
     scheme = request.headers.get("X-Forwarded-Proto") or request.scheme
     host = request.headers.get("X-Forwarded-Host") or request.host
     # Only get the first Forwarded-Host/Proto in case there are more than one
@@ -142,7 +142,7 @@ def format_baseurl(request: web.BaseRequest):
     return "{baseurl}{path}".format(baseurl=baseurl, path=request.path)
 
 
-def has_heartbeat_capable_version_tag(system_tags):
+def has_heartbeat_capable_version_tag(system_tags: List[str]) -> bool:
     """Check client version tag whether it is known to support heartbeats or not"""
     try:
         version_tags = [tag for tag in system_tags if tag.startswith('metaflow_version:')]
@@ -171,32 +171,32 @@ def has_heartbeat_capable_version_tag(system_tags):
 
 
 class DBConfiguration(object):
-    host: str = None
-    port: int = None
-    user: str = None
-    password: str = None
-    database_name: str = None
+    host: Optional[str] = None
+    port: Optional[int] = None
+    user: Optional[str] = None
+    password: Optional[str] = None
+    database_name: Optional[str] = None
 
-    # aiopg default pool sizes
-    # https://aiopg.readthedocs.io/en/stable/_modules/aiopg/pool.html#create_pool
-    pool_min: int = None  # aiopg default: 1
-    pool_max: int = None  # aiopg default: 10
+    pool_min: Optional[int] = None
+    pool_max: Optional[int] = None
 
-    timeout: int = None  # aiopg default: 60 (seconds)
+    timeout: Optional[int] = None
 
-    _dsn: str = None
+    _dsn: Optional[str] = None
 
-    def __init__(self,
-                 dsn: str = None,
-                 host: str = "localhost",
-                 port: int = 5432,
-                 user: str = "postgres",
-                 password: str = "postgres",
-                 database_name: str = "postgres",
-                 prefix="MF_METADATA_DB_",
-                 pool_min: int = 1,
-                 pool_max: int = 10,
-                 timeout: int = 60):
+    def __init__(
+        self,
+        dsn: Optional[str] = None,
+        host: str = "localhost",
+        port: int = 5432,
+        user: str = "postgres",
+        password: str = "postgres",
+        database_name: str = "postgres",
+        prefix: str = "MF_METADATA_DB_",
+        pool_min: int = 1,
+        pool_max: int = 10,
+        timeout: int = 60,
+    ) -> None:
 
         self._dsn = os.environ.get(prefix + "DSN", dsn)
         # Check if it is a BAD DSN String.
@@ -237,7 +237,7 @@ class DBConfiguration(object):
         self.timeout = int(os.environ.get(prefix + "TIMEOUT", timeout))
 
     @staticmethod
-    def _is_valid_dsn(dsn):
+    def _is_valid_dsn(dsn: str) -> Optional[bool]:
         try:
             psycopg2.extensions.parse_dsn(dsn)
             return True
@@ -246,12 +246,12 @@ class DBConfiguration(object):
             return None
 
     @property
-    def connection_string_url(self):
+    def connection_string_url(self) -> str:
         # postgresql://[user[:password]@][host][:port][/dbname][?param1=value1&...]
         return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=disable'
 
     @property
-    def dsn(self):
+    def dsn(self) -> str:
         if self._dsn is None:
             return psycopg2.extensions.make_dsn(
                 dbname=self._database_name,
@@ -264,21 +264,21 @@ class DBConfiguration(object):
             return self._dsn
 
     @property
-    def port(self):
+    def port(self) -> int:
         return self._port
 
     @property
-    def password(self):
+    def password(self) -> str:
         return self._password
 
     @property
-    def user(self):
+    def user(self) -> str:
         return self._user
 
     @property
-    def database_name(self):
+    def database_name(self) -> str:
         return self._database_name
 
     @property
-    def host(self):
+    def host(self) -> str:
         return self._host

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -6,6 +6,7 @@ import pkg_resources
 from multidict import MultiDict
 from urllib.parse import urlencode, quote
 from aiohttp import web
+from aiohttp.streams import StreamReader
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional
 import logging
@@ -31,7 +32,7 @@ logging.basicConfig(level=log_level)
 ORIGIN_TO_ALLOW_CORS_FROM = os.environ.get('ORIGIN_TO_ALLOW_CORS_FROM', None)
 
 
-async def read_body(request_content: web.StreamResponse) -> Any:
+async def read_body(request_content: StreamReader) -> Any:
     byte_array = bytearray()
     while not request_content.at_eof():
         data = await request_content.read(4)
@@ -57,8 +58,10 @@ def get_traceback_str() -> str:
     )
 
 
-def http_500(msg: str, id: Optional[str], traceback_str: str = get_traceback_str()) -> web.Response:
+def http_500(msg: str, id: Optional[str], traceback_str: Optional[str] = None) -> web.Response:
     # NOTE: worth considering if we want to expose tracebacks in the future in the api messages.
+    if traceback_str is None:
+        traceback_str = get_traceback_str()
     body = {
         'id': id,
         'traceback': traceback_str,


### PR DESCRIPTION
**Added type annotations to the foundational layers of the service:**

1. services/data/models.py - typed all __init__ parameters and serialize() return types for FlowRow, RunRow, StepRow, TaskRow, MetadataRow, ArtifactRow. Fixed class-level attributes to use Optional where they default to None.
2. db_utils.py - added param and return types to aiopg_exception_handling, get_db_ts_epoch_str, new_heartbeat_ts, translate_run_key, translate_task_key, get_exposed_run_id, get_exposed_task_id, get_latest_attempt_id_for_tasks.
3. __init__.py - typed read_body, get_traceback_str, http_500, handle_exceptions, format_response, web_response, format_qs, format_baseurl, has_heartbeat_capable_version_tag, and all DBConfiguration properties and constructor.

No behavioral changes - only type annotations added.

Part 1 of #4