### PR TITLE
Add type hints to API route handlers and utility functions

### DIFF
--- a/services/data/tagging_utils.py
+++ b/services/data/tagging_utils.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 from services.data.db_utils import DBResponse
 import copy
 
 
-async def apply_run_tags_to_db_response(flow_id, run_number, run_table_postgres, db_response: DBResponse) -> DBResponse:
+async def apply_run_tags_to_db_response(flow_id: str, run_number: str, run_table_postgres: Any, db_response: DBResponse) -> DBResponse:
     """
     We want read APIs to return steps, tasks and artifact objects with tags
     and system_tags set to their ancestral Run.

--- a/services/metadata_service/api/admin.py
+++ b/services/metadata_service/api/admin.py
@@ -16,14 +16,14 @@ from services.metadata_service.api.utils import METADATA_SERVICE_VERSION, \
 
 
 class AuthApi(object):
-    def __init__(self, app):
+    def __init__(self, app: web.Application) -> None:
         app.router.add_route("GET", "/auth/token",
                              self.get_authorization_token)
         app.router.add_route("GET", "/ping", self.ping)
         app.router.add_route("GET", "/version", self.version)
         app.router.add_route("GET", "/healthcheck", self.healthcheck)
 
-    async def version(self, request):
+    async def version(self, request: web.Request) -> web.Response:
         """
         ---
         description: Returns the version of the metadata service
@@ -39,7 +39,7 @@ class AuthApi(object):
         """
         return web.Response(text=str(METADATA_SERVICE_VERSION))
 
-    async def ping(self, request):
+    async def ping(self, request: web.Request) -> web.Response:
         """
         ---
         description: This end-point allow to test that service is up.
@@ -56,7 +56,7 @@ class AuthApi(object):
         return web.Response(text="pong", headers=MultiDict(
             {METADATA_SERVICE_HEADER: METADATA_SERVICE_VERSION}))
 
-    async def healthcheck(self, request):
+    async def healthcheck(self, request: web.Request) -> web.Response:
         """
         ---
         description: This end-point allow to test that service is up and
@@ -92,7 +92,7 @@ class AuthApi(object):
             cur.close()
         return web_response(status=status_code, body=json.dumps(status))
 
-    async def get_authorization_token(self, request):
+    async def get_authorization_token(self, request: web.Request) -> web.Response:
         """
         ---
         description: this is used exclusively for sandbox auth

--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -1,6 +1,7 @@
 from aiohttp import web
 from services.data.postgres_async_db import AsyncPostgresDB
 from services.data.db_utils import (
+    DBResponse,
     filter_artifacts_for_latest_attempt,
     filter_artifacts_by_attempt_id_for_tasks,
 )
@@ -18,7 +19,7 @@ class ArtificatsApi(object):
 
     _artifact_table = None
 
-    def __init__(self, app):
+    def __init__(self, app: web.Application) -> None:
         app.router.add_route(
             "GET",
             "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/"
@@ -65,7 +66,7 @@ class ArtificatsApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_artifact(self, request):
+    async def get_artifact(self, request: web.Request) -> DBResponse:
         """
         ---
         description: get all artifacts associated with the specified task.
@@ -119,7 +120,7 @@ class ArtificatsApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_artifact_with_attempt(self, request):
+    async def get_artifact_with_attempt(self, request: web.Request) -> DBResponse:
         """
         ---
         description: get all artifacts associated with the specified task.
@@ -177,7 +178,7 @@ class ArtificatsApi(object):
         db_response = await apply_run_tags_to_db_response(flow_id, run_number, self._async_run_table, db_response)
         return db_response
 
-    async def get_artifacts_by_task(self, request):
+    async def get_artifacts_by_task(self, request: web.Request) -> web.Response:
         """
         ---
         description: get all artifacts associated with the specified task.
@@ -232,7 +233,7 @@ class ArtificatsApi(object):
                 body=json.dumps(http_500(db_response.body)),
             )
 
-    async def get_artifacts_by_task_attempt(self, request):
+    async def get_artifacts_by_task_attempt(self, request: web.Request) -> web.Response:
         """
         ---
         description: get all artifacts associated with the specified task.
@@ -300,7 +301,7 @@ class ArtificatsApi(object):
                 body=json.dumps(http_500(db_response.body)),
             )
 
-    async def get_artifacts_by_step(self, request):
+    async def get_artifacts_by_step(self, request: web.Request) -> web.Response:
         """
         ---
         description: get all artifacts associated with the specified task.
@@ -349,7 +350,7 @@ class ArtificatsApi(object):
                 body=json.dumps(http_500(db_response.body)),
             )
 
-    async def get_artifacts_by_run(self, request):
+    async def get_artifacts_by_run(self, request: web.Request) -> web.Response:
         """
         ---
         description: get all artifacts associated with the specified task.
@@ -390,7 +391,7 @@ class ArtificatsApi(object):
                 body=json.dumps(http_500(db_response.body)),
             )
 
-    async def create_artifacts(self, request):
+    async def create_artifacts(self, request: web.Request) -> web.Response:
         """
         ---
         description: This end-point allow to test that service is up.

--- a/services/metadata_service/api/flow.py
+++ b/services/metadata_service/api/flow.py
@@ -1,16 +1,18 @@
 from services.data import FlowRow
 from services.data.postgres_async_db import AsyncPostgresDB
+from services.data.db_utils import DBResponse
 from services.utils import read_body
 from services.metadata_service.api.utils import format_response, \
     handle_exceptions
 import asyncio
+from aiohttp import web
 
 
 class FlowApi(object):
     _flow_table = None
     lock = asyncio.Lock()
 
-    def __init__(self, app):
+    def __init__(self, app: web.Application) -> None:
         app.router.add_route("GET", "/flows", self.get_all_flows)
         app.router.add_route("GET", "/flows/{flow_id}", self.get_flow)
         app.router.add_route("POST", "/flows/{flow_id}", self.create_flow)
@@ -18,7 +20,7 @@ class FlowApi(object):
 
     @format_response
     @handle_exceptions
-    async def create_flow(self, request):
+    async def create_flow(self, request: web.Request) -> DBResponse:
         """
         ---
         description: create/register a flow
@@ -65,7 +67,7 @@ class FlowApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_flow(self, request):
+    async def get_flow(self, request: web.Request) -> DBResponse:
         """
         ---
         description: Get flow by id
@@ -93,7 +95,7 @@ class FlowApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_all_flows(self, request):
+    async def get_all_flows(self, request: web.Request) -> DBResponse:
         """
         ---
         description: Get all flows

--- a/services/metadata_service/api/metadata.py
+++ b/services/metadata_service/api/metadata.py
@@ -1,5 +1,6 @@
 from aiohttp import web
 import json
+from services.data.db_utils import DBResponse
 from services.utils import read_body
 from services.metadata_service.api.utils import format_response, \
     handle_exceptions
@@ -11,7 +12,7 @@ class MetadataApi(object):
     _metadata_table = None
     lock = asyncio.Lock()
 
-    def __init__(self, app):
+    def __init__(self, app: web.Application) -> None:
         app.router.add_route(
             "GET",
             "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/"
@@ -34,7 +35,7 @@ class MetadataApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_metadata(self, request):
+    async def get_metadata(self, request: web.Request) -> DBResponse:
         """
         ---
         description: get all metadata associated with the specified task.
@@ -79,7 +80,7 @@ class MetadataApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_metadata_by_run(self, request):
+    async def get_metadata_by_run(self, request: web.Request) -> DBResponse:
         """
         ---
         description: get all metadata associated with the specified run.
@@ -110,7 +111,7 @@ class MetadataApi(object):
             flow_name, run_number
         )
 
-    async def create_metadata(self, request):
+    async def create_metadata(self, request: web.Request) -> web.Response:
         """
         ---
         description: persist metadata

--- a/services/metadata_service/api/run.py
+++ b/services/metadata_service/api/run.py
@@ -7,13 +7,14 @@ from services.utils import has_heartbeat_capable_version_tag, read_body
 from services.metadata_service.api.utils import format_response, \
     handle_exceptions
 from services.data.postgres_async_db import AsyncPostgresDB
+from aiohttp import web
 
 
 class RunApi(object):
     _run_table = None
     lock = asyncio.Lock()
 
-    def __init__(self, app):
+    def __init__(self, app: web.Application) -> None:
         app.router.add_route("GET", "/flows/{flow_id}/runs", self.get_all_runs)
         app.router.add_route(
             "GET", "/flows/{flow_id}/runs/{run_number}", self.get_run)
@@ -28,7 +29,7 @@ class RunApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_run(self, request):
+    async def get_run(self, request: web.Request) -> DBResponse:
         """
         ---
         description: Get run by run number
@@ -61,7 +62,7 @@ class RunApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_all_runs(self, request):
+    async def get_all_runs(self, request: web.Request) -> DBResponse:
         """
         ---
         description: Get all runs
@@ -86,7 +87,7 @@ class RunApi(object):
 
     @format_response
     @handle_exceptions
-    async def create_run(self, request):
+    async def create_run(self, request: web.Request) -> DBResponse:
         """
         ---
         description: create run and generate run id
@@ -144,7 +145,7 @@ class RunApi(object):
 
     @format_response
     @handle_exceptions
-    async def mutate_user_tags(self, request):
+    async def mutate_user_tags(self, request: web.Request) -> DBResponse:
         """
         ---
         description: mutate user tags
@@ -242,7 +243,7 @@ class RunApi(object):
 
     @format_response
     @handle_exceptions
-    async def runs_heartbeat(self, request):
+    async def runs_heartbeat(self, request: web.Request) -> DBResponse:
         """
         ---
         description: update hb

--- a/services/metadata_service/api/step.py
+++ b/services/metadata_service/api/step.py
@@ -1,15 +1,17 @@
 from services.data import StepRow
+from services.data.db_utils import DBResponse
 from services.data.tagging_utils import apply_run_tags_to_db_response
 from services.utils import read_body
 from services.metadata_service.api.utils import format_response, \
     handle_exceptions
 from services.data.postgres_async_db import AsyncPostgresDB
+from aiohttp import web
 
 
 class StepApi(object):
     _step_table = None
 
-    def __init__(self, app):
+    def __init__(self, app: web.Application) -> None:
         app.router.add_route(
             "GET", "/flows/{flow_id}/runs/{run_number}/steps", self.get_steps
         )
@@ -28,7 +30,7 @@ class StepApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_steps(self, request):
+    async def get_steps(self, request: web.Request) -> DBResponse:
         """
         ---
         description: get all steps associated with the specified run.
@@ -61,7 +63,7 @@ class StepApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_step(self, request):
+    async def get_step(self, request: web.Request) -> DBResponse:
         """
         ---
         description: get specified step.
@@ -105,7 +107,7 @@ class StepApi(object):
 
     @format_response
     @handle_exceptions
-    async def create_step(self, request):
+    async def create_step(self, request: web.Request) -> DBResponse:
         """
         ---
         description: Create step.

--- a/services/metadata_service/api/task.py
+++ b/services/metadata_service/api/task.py
@@ -1,5 +1,6 @@
 from services.data import TaskRow
 from services.data.postgres_async_db import AsyncPostgresDB
+from services.data.db_utils import DBResponse
 from services.data.tagging_utils import apply_run_tags_to_db_response
 from services.utils import has_heartbeat_capable_version_tag, read_body
 from services.metadata_service.api.utils import format_response, \
@@ -13,7 +14,7 @@ class TaskApi(object):
     _task_table = None
     lock = asyncio.Lock()
 
-    def __init__(self, app):
+    def __init__(self, app: web.Application) -> None:
         app.router.add_route(
             "GET",
             "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks",
@@ -38,7 +39,7 @@ class TaskApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_tasks(self, request):
+    async def get_tasks(self, request: web.Request) -> DBResponse:
         """
         ---
         description: get all tasks associated with the specified step.
@@ -78,7 +79,7 @@ class TaskApi(object):
 
     @format_response
     @handle_exceptions
-    async def get_task(self, request):
+    async def get_task(self, request: web.Request) -> DBResponse:
         """
         ---
         description: get all artifacts associated with the specified task.
@@ -125,7 +126,7 @@ class TaskApi(object):
 
     @format_response
     @handle_exceptions
-    async def create_task(self, request):
+    async def create_task(self, request: web.Request) -> DBResponse:
         """
         ---
         description: This end-point allow to test that service is up.
@@ -211,7 +212,7 @@ class TaskApi(object):
 
     @format_response
     @handle_exceptions
-    async def tasks_heartbeat(self, request):
+    async def tasks_heartbeat(self, request: web.Request) -> DBResponse:
         """
         ---
         description: update hb

--- a/services/metadata_service/api/utils.py
+++ b/services/metadata_service/api/utils.py
@@ -1,5 +1,6 @@
 import json
 from functools import wraps
+from typing import Any, Callable, Optional
 
 import pkg_resources
 import collections
@@ -15,7 +16,7 @@ METADATA_SERVICE_HEADER = 'METADATA_SERVICE_VERSION'
 ServiceResponse = collections.namedtuple("ServiceResponse", "response_code body")
 
 
-def format_response(func):
+def format_response(func: Callable) -> Callable:
     """handle formatting"""
 
     @wraps(func)
@@ -29,7 +30,7 @@ def format_response(func):
     return wrapper
 
 
-def web_response(status: int, body):
+def web_response(status: int, body: Any) -> web.Response:
     return web.Response(status=status,
                         body=json.dumps(body),
                         headers=MultiDict(
@@ -37,7 +38,7 @@ def web_response(status: int, body):
                              METADATA_SERVICE_HEADER: METADATA_SERVICE_VERSION}))
 
 
-def http_500(msg, traceback_str=None):
+def http_500(msg: str, traceback_str: Optional[str] = None) -> "ServiceResponse":
     # NOTE: worth considering if we want to expose tracebacks in the future in the api messages.
     if traceback_str is None:
         traceback_str = get_traceback_str()
@@ -52,7 +53,7 @@ def http_500(msg, traceback_str=None):
     return ServiceResponse(500, body)
 
 
-def handle_exceptions(func):
+def handle_exceptions(func: Callable) -> Callable:
     """Catch exceptions and return appropriate HTTP error."""
 
     @wraps(func)


### PR DESCRIPTION
Added type annotations to the metadata service API layer and related utilities.

**Changes:**
1. [utils.py](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - typed [format_response](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [handle_exceptions](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [web_response](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [http_500](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with proper [Callable](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [Any](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [Optional](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) types
2. [admin.py](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - typed [AuthApi.__init__](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and all request handlers ([version](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [ping](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [healthcheck](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [get_authorization_token](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
3. [flow.py](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - typed [FlowApi.__init__](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and handlers ([create_flow](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [get_flow](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [get_all_flows](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
4. [run.py](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - typed [RunApi.__init__](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and handlers ([get_run](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [get_all_runs](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [create_run](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [mutate_user_tags](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [runs_heartbeat](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
5. [step.py](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - typed [StepApi.__init__](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and handlers ([get_steps](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [get_step](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [create_step](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
6. [task.py](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - typed [TaskApi.__init__](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and handlers ([get_tasks](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [get_task](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [create_task](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [tasks_heartbeat](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
7. [metadata.py](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - typed [MetadataApi.__init__](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and handlers ([get_metadata](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [get_metadata_by_run](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [create_metadata](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
8. [artifact.py](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - typed [ArtificatsApi.__init__](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and all 8 handlers
9. [tagging_utils.py](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - typed [flow_id](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [run_number](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [run_table_postgres](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) params in [apply_run_tags_to_db_response](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

All [__init__](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) methods take [app: web.Application](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and return None. Decorated handlers return [DBResponse](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), undecorated ones return [web.Response](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html). All request params typed as [web.Request](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Part 3 of #4
