### PR TITLE
feat: server-side tag filtering for metadata service

### DIFF
--- a/services/metadata_service/api/flow.py
+++ b/services/metadata_service/api/flow.py
@@ -99,6 +99,12 @@ class FlowApi(object):
         description: Get all flows
         tags:
         - Flow
+        parameters:
+        - name: "_tag"
+          in: "query"
+          description: "Filter by tag value. Matches against both user tags and system tags. Can be specified multiple times; all tags must match (AND logic)."
+          required: false
+          type: "string"
         produces:
         - text/plain
         responses:
@@ -107,4 +113,19 @@ class FlowApi(object):
             "405":
                 description: invalid HTTP Method
         """
-        return await self._async_table.get_all_flows()
+        tags = request.query.getall("_tag", [])
+
+        if not tags:
+            return await self._async_table.get_all_flows()
+
+        conditions = [
+            "tags||system_tags ?& array[{}]".format(
+                ",".join(["%s"] * len(tags))
+            )
+        ]
+        values = list(tags)
+
+        response, _ = await self._async_table.find_records(
+            conditions=conditions, values=values
+        )
+        return response

--- a/services/metadata_service/api/flow.py
+++ b/services/metadata_service/api/flow.py
@@ -2,7 +2,7 @@ from services.data import FlowRow
 from services.data.postgres_async_db import AsyncPostgresDB
 from services.utils import read_body
 from services.metadata_service.api.utils import format_response, \
-    handle_exceptions
+    handle_exceptions, tag_conditions
 import asyncio
 
 
@@ -100,9 +100,9 @@ class FlowApi(object):
         tags:
         - Flow
         parameters:
-        - name: "_tag"
+        - name: "_tags"
           in: "query"
-          description: "Filter by tag value. Matches against both user tags and system tags. Can be specified multiple times; all tags must match (AND logic)."
+          description: "Filter by tag values (comma-separated). Matches against both user tags and system tags. All tags must match (AND logic)."
           required: false
           type: "string"
         produces:
@@ -113,19 +113,12 @@ class FlowApi(object):
             "405":
                 description: invalid HTTP Method
         """
-        tags = request.query.getall("_tag", [])
+        tag_conds, tag_vals = tag_conditions(request.query)
 
-        if not tags:
+        if not tag_conds:
             return await self._async_table.get_all_flows()
 
-        conditions = [
-            "tags||system_tags ?& array[{}]".format(
-                ",".join(["%s"] * len(tags))
-            )
-        ]
-        values = list(tags)
-
         response, _ = await self._async_table.find_records(
-            conditions=conditions, values=values
+            conditions=tag_conds, values=tag_vals
         )
         return response

--- a/services/metadata_service/api/run.py
+++ b/services/metadata_service/api/run.py
@@ -5,7 +5,7 @@ from services.data.db_utils import DBResponse
 from services.data.models import RunRow
 from services.utils import has_heartbeat_capable_version_tag, read_body
 from services.metadata_service.api.utils import format_response, \
-    handle_exceptions
+    handle_exceptions, tag_conditions
 from services.data.postgres_async_db import AsyncPostgresDB
 
 
@@ -73,9 +73,9 @@ class RunApi(object):
           description: "flow_id"
           required: true
           type: "string"
-        - name: "_tag"
+        - name: "_tags"
           in: "query"
-          description: "Filter by tag value. Matches against both user tags and system tags. Can be specified multiple times; all tags must match (AND logic)."
+          description: "Filter by tag values (comma-separated). Matches against both user tags and system tags. All tags must match (AND logic)."
           required: false
           type: "string"
         produces:
@@ -87,19 +87,13 @@ class RunApi(object):
                 description: invalid HTTP Method
         """
         flow_name = request.match_info.get("flow_id")
-        tags = request.query.getall("_tag", [])
+        tag_conds, tag_vals = tag_conditions(request.query)
 
-        if not tags:
+        if not tag_conds:
             return await self._async_table.get_all_runs(flow_name)
 
-        conditions = ["flow_id = %s"]
-        values = [flow_name]
-        conditions.append(
-            "tags||system_tags ?& array[{}]".format(
-                ",".join(["%s"] * len(tags))
-            )
-        )
-        values.extend(tags)
+        conditions = ["flow_id = %s"] + tag_conds
+        values = [flow_name] + tag_vals
 
         response, _ = await self._async_table.find_records(
             conditions=conditions, values=values

--- a/services/metadata_service/api/run.py
+++ b/services/metadata_service/api/run.py
@@ -73,6 +73,11 @@ class RunApi(object):
           description: "flow_id"
           required: true
           type: "string"
+        - name: "_tag"
+          in: "query"
+          description: "Filter by tag value. Matches against both user tags and system tags. Can be specified multiple times; all tags must match (AND logic)."
+          required: false
+          type: "string"
         produces:
         - text/plain
         responses:
@@ -82,7 +87,24 @@ class RunApi(object):
                 description: invalid HTTP Method
         """
         flow_name = request.match_info.get("flow_id")
-        return await self._async_table.get_all_runs(flow_name)
+        tags = request.query.getall("_tag", [])
+
+        if not tags:
+            return await self._async_table.get_all_runs(flow_name)
+
+        conditions = ["flow_id = %s"]
+        values = [flow_name]
+        conditions.append(
+            "tags||system_tags ?& array[{}]".format(
+                ",".join(["%s"] * len(tags))
+            )
+        )
+        values.extend(tags)
+
+        response, _ = await self._async_table.find_records(
+            conditions=conditions, values=values
+        )
+        return response
 
     @format_response
     @handle_exceptions

--- a/services/metadata_service/api/utils.py
+++ b/services/metadata_service/api/utils.py
@@ -82,8 +82,7 @@ def tag_conditions(query):
     if not tags:
         return [], []
 
-    condition = (
-        "COALESCE(tags, '[]'::jsonb) || COALESCE(system_tags, '[]'::jsonb) "
-        "?& array[{}]".format(",".join(["%s"] * len(tags)))
+    condition = "tags||system_tags ?& array[{}]".format(
+        ",".join(["%s"] * len(tags))
     )
     return [condition], list(tags)

--- a/services/metadata_service/api/utils.py
+++ b/services/metadata_service/api/utils.py
@@ -63,3 +63,27 @@ def handle_exceptions(func):
             return http_500(str(err))
 
     return wrapper
+
+
+def tag_conditions(query):
+    """Build SQL conditions for tag filtering from query parameters.
+
+    Supports the _tags parameter with comma-separated values.
+    Uses the JSONB ?& operator to match all specified tags
+    against the combined tags and system_tags columns.
+
+    Returns (conditions, values) tuple to be passed to find_records().
+    """
+    raw = query.get("_tags", "")
+    if not raw:
+        return [], []
+
+    tags = [t.strip() for t in raw.split(",") if t.strip()]
+    if not tags:
+        return [], []
+
+    condition = (
+        "COALESCE(tags, '[]'::jsonb) || COALESCE(system_tags, '[]'::jsonb) "
+        "?& array[{}]".format(",".join(["%s"] * len(tags)))
+    )
+    return [condition], list(tags)

--- a/services/metadata_service/api/utils.py
+++ b/services/metadata_service/api/utils.py
@@ -66,14 +66,7 @@ def handle_exceptions(func):
 
 
 def tag_conditions(query):
-    """Build SQL conditions for tag filtering from query parameters.
-
-    Supports the _tags parameter with comma-separated values.
-    Uses the JSONB ?& operator to match all specified tags
-    against the combined tags and system_tags columns.
-
-    Returns (conditions, values) tuple to be passed to find_records().
-    """
+    """Parse _tags from query, return (conditions, values) for find_records."""
     raw = query.get("_tags", "")
     if not raw:
         return [], []

--- a/services/metadata_service/tests/integration_tests/tag_filtering_test.py
+++ b/services/metadata_service/tests/integration_tests/tag_filtering_test.py
@@ -1,0 +1,95 @@
+import json
+
+from .utils import (
+    cli, db,
+    add_flow, add_run,
+)
+import pytest
+
+pytestmark = [pytest.mark.integration_tests]
+
+
+async def test_runs_get_without_tags_returns_all(cli, db):
+    _flow = (await add_flow(db, flow_id="TagTestFlow")).body
+    await add_run(db, flow_id="TagTestFlow", tags=["a"], system_tags=["sys:one"])
+    await add_run(db, flow_id="TagTestFlow", tags=["b"], system_tags=["sys:two"])
+
+    response = await cli.get("/flows/TagTestFlow/runs")
+    assert response.status == 200
+    body = json.loads(await response.text())
+    assert len(body) == 2
+
+
+async def test_runs_get_filter_single_tag(cli, db):
+    _flow = (await add_flow(db, flow_id="TagTestFlow")).body
+    await add_run(db, flow_id="TagTestFlow", tags=["env:prod"], system_tags=["runtime:dev"])
+    await add_run(db, flow_id="TagTestFlow", tags=["env:staging"], system_tags=["runtime:dev"])
+
+    response = await cli.get("/flows/TagTestFlow/runs?_tags=env:prod")
+    assert response.status == 200
+    body = json.loads(await response.text())
+    assert len(body) == 1
+    assert "env:prod" in body[0]["tags"]
+
+
+async def test_runs_get_filter_multiple_tags(cli, db):
+    _flow = (await add_flow(db, flow_id="TagTestFlow")).body
+    await add_run(db, flow_id="TagTestFlow", tags=["env:prod", "team:ml"], system_tags=["runtime:dev"])
+    await add_run(db, flow_id="TagTestFlow", tags=["env:prod"], system_tags=["runtime:dev"])
+
+    response = await cli.get("/flows/TagTestFlow/runs?_tags=env:prod,team:ml")
+    assert response.status == 200
+    body = json.loads(await response.text())
+    assert len(body) == 1
+    assert "team:ml" in body[0]["tags"]
+
+
+async def test_runs_get_filter_matches_system_tags(cli, db):
+    _flow = (await add_flow(db, flow_id="TagTestFlow")).body
+    await add_run(db, flow_id="TagTestFlow", tags=["user_tag"], system_tags=["runtime:dev"])
+    await add_run(db, flow_id="TagTestFlow", tags=["user_tag"], system_tags=["runtime:prod"])
+
+    response = await cli.get("/flows/TagTestFlow/runs?_tags=runtime:dev")
+    assert response.status == 200
+    body = json.loads(await response.text())
+    assert len(body) == 1
+
+
+async def test_runs_get_filter_no_matches(cli, db):
+    _flow = (await add_flow(db, flow_id="TagTestFlow")).body
+    await add_run(db, flow_id="TagTestFlow", tags=["env:prod"], system_tags=["runtime:dev"])
+
+    response = await cli.get("/flows/TagTestFlow/runs?_tags=nonexistent")
+    assert response.status == 200
+    body = json.loads(await response.text())
+    assert len(body) == 0
+
+
+async def test_flows_get_without_tags_returns_all(cli, db):
+    await add_flow(db, flow_id="FlowA", tags=["team:ml"], system_tags=["runtime:dev"])
+    await add_flow(db, flow_id="FlowB", tags=["team:infra"], system_tags=["runtime:prod"])
+
+    response = await cli.get("/flows")
+    assert response.status == 200
+    body = json.loads(await response.text())
+    assert len(body) == 2
+
+
+async def test_flows_get_filter_single_tag(cli, db):
+    await add_flow(db, flow_id="FlowA", tags=["team:ml"], system_tags=["runtime:dev"])
+    await add_flow(db, flow_id="FlowB", tags=["team:infra"], system_tags=["runtime:dev"])
+
+    response = await cli.get("/flows?_tags=team:ml")
+    assert response.status == 200
+    body = json.loads(await response.text())
+    assert len(body) == 1
+    assert body[0]["flow_id"] == "FlowA"
+
+
+async def test_flows_get_filter_no_matches(cli, db):
+    await add_flow(db, flow_id="FlowA", tags=["team:ml"], system_tags=["runtime:dev"])
+
+    response = await cli.get("/flows?_tags=nonexistent")
+    assert response.status == 200
+    body = json.loads(await response.text())
+    assert len(body) == 0

--- a/services/metadata_service/tests/unit_tests/tag_filtering_test.py
+++ b/services/metadata_service/tests/unit_tests/tag_filtering_test.py
@@ -63,7 +63,7 @@ class TestTagConditionsUtility:
         query = CIMultiDictProxy(CIMultiDict({"_tags": "env:prod"}))
         conditions, values = tag_conditions(query)
         assert len(conditions) == 1
-        assert "COALESCE" in conditions[0]
+        assert "tags||system_tags" in conditions[0]
         assert "?&" in conditions[0]
         assert values == ["env:prod"]
 

--- a/services/metadata_service/tests/unit_tests/tag_filtering_test.py
+++ b/services/metadata_service/tests/unit_tests/tag_filtering_test.py
@@ -1,19 +1,17 @@
-import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from multidict import CIMultiDict, CIMultiDictProxy
 
 from services.data.db_utils import DBResponse, DBPagination
+from services.metadata_service.api.utils import tag_conditions
 from services.metadata_service.api.run import RunApi
 from services.metadata_service.api.flow import FlowApi
 
 
 def _make_request(query_params=None, match_info=None):
     request = MagicMock()
-    if query_params is None:
-        query_params = {}
     multi = CIMultiDict()
-    for k, v in query_params.items():
+    for k, v in (query_params or {}).items():
         if isinstance(v, list):
             for item in v:
                 multi.add(k, item)
@@ -46,6 +44,65 @@ def _flow_record(flow_id="TestFlow", tags=None, system_tags=None):
     }
 
 
+def _mock_find_records(body):
+    return AsyncMock(
+        return_value=(
+            DBResponse(response_code=200, body=body),
+            DBPagination(limit=0, offset=0, count=len(body), page=1),
+        )
+    )
+
+
+class TestTagConditionsUtility:
+    def test_empty_query_returns_empty(self):
+        conditions, values = tag_conditions(CIMultiDictProxy(CIMultiDict()))
+        assert conditions == []
+        assert values == []
+
+    def test_single_tag(self):
+        query = CIMultiDictProxy(CIMultiDict({"_tags": "env:prod"}))
+        conditions, values = tag_conditions(query)
+        assert len(conditions) == 1
+        assert "COALESCE" in conditions[0]
+        assert "?&" in conditions[0]
+        assert values == ["env:prod"]
+
+    def test_comma_separated_tags(self):
+        query = CIMultiDictProxy(CIMultiDict({"_tags": "env:prod,user:alice"}))
+        conditions, values = tag_conditions(query)
+        assert len(conditions) == 1
+        assert conditions[0].count("%s") == 2
+        assert values == ["env:prod", "user:alice"]
+
+    def test_whitespace_in_tags_is_trimmed(self):
+        query = CIMultiDictProxy(CIMultiDict({"_tags": " env:prod , user:alice "}))
+        conditions, values = tag_conditions(query)
+        assert values == ["env:prod", "user:alice"]
+
+    def test_empty_tags_string_returns_empty(self):
+        query = CIMultiDictProxy(CIMultiDict({"_tags": ""}))
+        conditions, values = tag_conditions(query)
+        assert conditions == []
+        assert values == []
+
+    def test_only_commas_returns_empty(self):
+        query = CIMultiDictProxy(CIMultiDict({"_tags": ",,,"}))
+        conditions, values = tag_conditions(query)
+        assert conditions == []
+        assert values == []
+
+    def test_special_characters_in_tags(self):
+        query = CIMultiDictProxy(CIMultiDict({"_tags": "user:alice@corp,runtime:dev-v2.1"}))
+        conditions, values = tag_conditions(query)
+        assert values == ["user:alice@corp", "runtime:dev-v2.1"]
+
+    def test_coalesce_null_safety(self):
+        query = CIMultiDictProxy(CIMultiDict({"_tags": "sometag"}))
+        conditions, _ = tag_conditions(query)
+        assert "COALESCE(tags, '[]'::jsonb)" in conditions[0]
+        assert "COALESCE(system_tags, '[]'::jsonb)" in conditions[0]
+
+
 class TestRunTagFiltering:
     @pytest.fixture
     def run_api(self):
@@ -57,7 +114,7 @@ class TestRunTagFiltering:
         api._async_table = MagicMock()
         return api
 
-    async def test_no_tag_param_returns_all_records(self, run_api):
+    async def test_no_tags_param_returns_all_records(self, run_api):
         records = [_run_record(run_number=1), _run_record(run_number=2)]
         run_api._async_table.get_all_runs = AsyncMock(
             return_value=DBResponse(response_code=200, body=records)
@@ -70,58 +127,40 @@ class TestRunTagFiltering:
         assert result.response_code == 200
         assert len(result.body) == 2
 
-    async def test_single_tag_calls_find_records(self, run_api):
+    async def test_tags_param_calls_find_records(self, run_api):
         records = [_run_record(run_number=1, tags=["env:prod"])]
-        run_api._async_table.find_records = AsyncMock(
-            return_value=(DBResponse(response_code=200, body=records),
-                          DBPagination(limit=0, offset=0, count=1, page=1))
-        )
+        run_api._async_table.find_records = _mock_find_records(records)
         request = _make_request(
-            query_params={"_tag": "env:prod"},
+            query_params={"_tags": "env:prod"},
             match_info={"flow_id": "TestFlow"},
         )
 
         result = await run_api.get_all_runs.__wrapped__.__wrapped__(run_api, request)
 
         run_api._async_table.find_records.assert_awaited_once()
-        call_args = run_api._async_table.find_records.call_args
-        conditions = call_args.kwargs.get("conditions", call_args[1].get("conditions", call_args[0][0] if call_args[0] else None))
-        values = call_args.kwargs.get("values", call_args[1].get("values", call_args[0][1] if len(call_args[0]) > 1 else None))
-
-        assert "flow_id = %s" in conditions
-        assert any("?&" in c for c in conditions)
-        assert "TestFlow" in values
-        assert "env:prod" in values
+        call_kwargs = run_api._async_table.find_records.call_args.kwargs
+        assert "flow_id = %s" in call_kwargs["conditions"]
+        assert "TestFlow" in call_kwargs["values"]
+        assert "env:prod" in call_kwargs["values"]
         assert result.response_code == 200
 
-    async def test_multiple_tags_all_passed_to_query(self, run_api):
-        run_api._async_table.find_records = AsyncMock(
-            return_value=(DBResponse(response_code=200, body=[]),
-                          DBPagination(limit=0, offset=0, count=0, page=1))
-        )
+    async def test_comma_separated_tags(self, run_api):
+        run_api._async_table.find_records = _mock_find_records([])
         request = _make_request(
-            query_params={"_tag": ["env:prod", "user:alice"]},
+            query_params={"_tags": "env:prod,user:alice"},
             match_info={"flow_id": "TestFlow"},
         )
 
-        result = await run_api.get_all_runs.__wrapped__.__wrapped__(run_api, request)
+        await run_api.get_all_runs.__wrapped__.__wrapped__(run_api, request)
 
-        call_args = run_api._async_table.find_records.call_args
-        conditions = call_args.kwargs.get("conditions", call_args[1].get("conditions"))
-        values = call_args.kwargs.get("values", call_args[1].get("values"))
+        call_kwargs = run_api._async_table.find_records.call_args.kwargs
+        assert "env:prod" in call_kwargs["values"]
+        assert "user:alice" in call_kwargs["values"]
 
-        tag_condition = [c for c in conditions if "?&" in c][0]
-        assert "%s,%s" in tag_condition or tag_condition.count("%s") == 2
-        assert "env:prod" in values
-        assert "user:alice" in values
-
-    async def test_no_matching_records_returns_empty(self, run_api):
-        run_api._async_table.find_records = AsyncMock(
-            return_value=(DBResponse(response_code=200, body=[]),
-                          DBPagination(limit=0, offset=0, count=0, page=1))
-        )
+    async def test_no_matches_returns_empty(self, run_api):
+        run_api._async_table.find_records = _mock_find_records([])
         request = _make_request(
-            query_params={"_tag": "nonexistent"},
+            query_params={"_tags": "nonexistent"},
             match_info={"flow_id": "TestFlow"},
         )
 
@@ -130,23 +169,18 @@ class TestRunTagFiltering:
         assert result.response_code == 200
         assert result.body == []
 
-    async def test_tag_filter_uses_combined_tags_system_tags(self, run_api):
-        run_api._async_table.find_records = AsyncMock(
-            return_value=(DBResponse(response_code=200, body=[]),
-                          DBPagination(limit=0, offset=0, count=0, page=1))
-        )
+    async def test_system_tags_only_match(self, run_api):
+        records = [_run_record(run_number=1, system_tags=["runtime:dev"])]
+        run_api._async_table.find_records = _mock_find_records(records)
         request = _make_request(
-            query_params={"_tag": "runtime:dev"},
+            query_params={"_tags": "runtime:dev"},
             match_info={"flow_id": "TestFlow"},
         )
 
-        await run_api.get_all_runs.__wrapped__.__wrapped__(run_api, request)
+        result = await run_api.get_all_runs.__wrapped__.__wrapped__(run_api, request)
 
-        call_args = run_api._async_table.find_records.call_args
-        conditions = call_args.kwargs.get("conditions", call_args[1].get("conditions"))
-
-        tag_condition = [c for c in conditions if "?&" in c][0]
-        assert "tags||system_tags" in tag_condition
+        assert result.response_code == 200
+        assert len(result.body) == 1
 
 
 class TestFlowTagFiltering:
@@ -160,7 +194,7 @@ class TestFlowTagFiltering:
         api._async_table = MagicMock()
         return api
 
-    async def test_no_tag_param_returns_all_flows(self, flow_api):
+    async def test_no_tags_param_returns_all_flows(self, flow_api):
         records = [_flow_record("FlowA"), _flow_record("FlowB")]
         flow_api._async_table.get_all_flows = AsyncMock(
             return_value=DBResponse(response_code=200, body=records)
@@ -173,46 +207,19 @@ class TestFlowTagFiltering:
         assert result.response_code == 200
         assert len(result.body) == 2
 
-    async def test_single_tag_filters_flows(self, flow_api):
+    async def test_tags_param_filters_flows(self, flow_api):
         records = [_flow_record("FlowA", tags=["team:ml"])]
-        flow_api._async_table.find_records = AsyncMock(
-            return_value=(DBResponse(response_code=200, body=records),
-                          DBPagination(limit=0, offset=0, count=1, page=1))
-        )
-        request = _make_request(query_params={"_tag": "team:ml"})
+        flow_api._async_table.find_records = _mock_find_records(records)
+        request = _make_request(query_params={"_tags": "team:ml"})
 
         result = await flow_api.get_all_flows.__wrapped__.__wrapped__(flow_api, request)
 
         flow_api._async_table.find_records.assert_awaited_once()
-        call_args = flow_api._async_table.find_records.call_args
-        conditions = call_args.kwargs.get("conditions", call_args[1].get("conditions"))
-        values = call_args.kwargs.get("values", call_args[1].get("values"))
-
-        assert any("?&" in c for c in conditions)
-        assert "team:ml" in values
         assert result.response_code == 200
 
-    async def test_multiple_tags_filters_flows(self, flow_api):
-        flow_api._async_table.find_records = AsyncMock(
-            return_value=(DBResponse(response_code=200, body=[]),
-                          DBPagination(limit=0, offset=0, count=0, page=1))
-        )
-        request = _make_request(query_params={"_tag": ["team:ml", "env:prod"]})
-
-        result = await flow_api.get_all_flows.__wrapped__.__wrapped__(flow_api, request)
-
-        call_args = flow_api._async_table.find_records.call_args
-        values = call_args.kwargs.get("values", call_args[1].get("values"))
-
-        assert "team:ml" in values
-        assert "env:prod" in values
-
     async def test_no_matching_flows_returns_empty(self, flow_api):
-        flow_api._async_table.find_records = AsyncMock(
-            return_value=(DBResponse(response_code=200, body=[]),
-                          DBPagination(limit=0, offset=0, count=0, page=1))
-        )
-        request = _make_request(query_params={"_tag": "nonexistent"})
+        flow_api._async_table.find_records = _mock_find_records([])
+        request = _make_request(query_params={"_tags": "nonexistent"})
 
         result = await flow_api.get_all_flows.__wrapped__.__wrapped__(flow_api, request)
 

--- a/services/metadata_service/tests/unit_tests/tag_filtering_test.py
+++ b/services/metadata_service/tests/unit_tests/tag_filtering_test.py
@@ -1,0 +1,220 @@
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from multidict import CIMultiDict, CIMultiDictProxy
+
+from services.data.db_utils import DBResponse, DBPagination
+from services.metadata_service.api.run import RunApi
+from services.metadata_service.api.flow import FlowApi
+
+
+def _make_request(query_params=None, match_info=None):
+    request = MagicMock()
+    if query_params is None:
+        query_params = {}
+    multi = CIMultiDict()
+    for k, v in query_params.items():
+        if isinstance(v, list):
+            for item in v:
+                multi.add(k, item)
+        else:
+            multi.add(k, v)
+    request.query = CIMultiDictProxy(multi)
+    request.match_info = match_info or {}
+    return request
+
+
+def _run_record(flow_id="TestFlow", run_number=1, tags=None, system_tags=None):
+    return {
+        "flow_id": flow_id,
+        "run_number": run_number,
+        "user_name": "testuser",
+        "ts_epoch": 1000000,
+        "tags": tags or [],
+        "system_tags": system_tags or [],
+        "last_heartbeat_ts": None,
+    }
+
+
+def _flow_record(flow_id="TestFlow", tags=None, system_tags=None):
+    return {
+        "flow_id": flow_id,
+        "user_name": "testuser",
+        "ts_epoch": 1000000,
+        "tags": tags or [],
+        "system_tags": system_tags or [],
+    }
+
+
+class TestRunTagFiltering:
+    @pytest.fixture
+    def run_api(self):
+        app = MagicMock()
+        app.router = MagicMock()
+        app.router.add_route = MagicMock()
+        with patch("services.metadata_service.api.run.AsyncPostgresDB"):
+            api = RunApi(app)
+        api._async_table = MagicMock()
+        return api
+
+    async def test_no_tag_param_returns_all_records(self, run_api):
+        records = [_run_record(run_number=1), _run_record(run_number=2)]
+        run_api._async_table.get_all_runs = AsyncMock(
+            return_value=DBResponse(response_code=200, body=records)
+        )
+        request = _make_request(match_info={"flow_id": "TestFlow"})
+
+        result = await run_api.get_all_runs.__wrapped__.__wrapped__(run_api, request)
+
+        run_api._async_table.get_all_runs.assert_awaited_once_with("TestFlow")
+        assert result.response_code == 200
+        assert len(result.body) == 2
+
+    async def test_single_tag_calls_find_records(self, run_api):
+        records = [_run_record(run_number=1, tags=["env:prod"])]
+        run_api._async_table.find_records = AsyncMock(
+            return_value=(DBResponse(response_code=200, body=records),
+                          DBPagination(limit=0, offset=0, count=1, page=1))
+        )
+        request = _make_request(
+            query_params={"_tag": "env:prod"},
+            match_info={"flow_id": "TestFlow"},
+        )
+
+        result = await run_api.get_all_runs.__wrapped__.__wrapped__(run_api, request)
+
+        run_api._async_table.find_records.assert_awaited_once()
+        call_args = run_api._async_table.find_records.call_args
+        conditions = call_args.kwargs.get("conditions", call_args[1].get("conditions", call_args[0][0] if call_args[0] else None))
+        values = call_args.kwargs.get("values", call_args[1].get("values", call_args[0][1] if len(call_args[0]) > 1 else None))
+
+        assert "flow_id = %s" in conditions
+        assert any("?&" in c for c in conditions)
+        assert "TestFlow" in values
+        assert "env:prod" in values
+        assert result.response_code == 200
+
+    async def test_multiple_tags_all_passed_to_query(self, run_api):
+        run_api._async_table.find_records = AsyncMock(
+            return_value=(DBResponse(response_code=200, body=[]),
+                          DBPagination(limit=0, offset=0, count=0, page=1))
+        )
+        request = _make_request(
+            query_params={"_tag": ["env:prod", "user:alice"]},
+            match_info={"flow_id": "TestFlow"},
+        )
+
+        result = await run_api.get_all_runs.__wrapped__.__wrapped__(run_api, request)
+
+        call_args = run_api._async_table.find_records.call_args
+        conditions = call_args.kwargs.get("conditions", call_args[1].get("conditions"))
+        values = call_args.kwargs.get("values", call_args[1].get("values"))
+
+        tag_condition = [c for c in conditions if "?&" in c][0]
+        assert "%s,%s" in tag_condition or tag_condition.count("%s") == 2
+        assert "env:prod" in values
+        assert "user:alice" in values
+
+    async def test_no_matching_records_returns_empty(self, run_api):
+        run_api._async_table.find_records = AsyncMock(
+            return_value=(DBResponse(response_code=200, body=[]),
+                          DBPagination(limit=0, offset=0, count=0, page=1))
+        )
+        request = _make_request(
+            query_params={"_tag": "nonexistent"},
+            match_info={"flow_id": "TestFlow"},
+        )
+
+        result = await run_api.get_all_runs.__wrapped__.__wrapped__(run_api, request)
+
+        assert result.response_code == 200
+        assert result.body == []
+
+    async def test_tag_filter_uses_combined_tags_system_tags(self, run_api):
+        run_api._async_table.find_records = AsyncMock(
+            return_value=(DBResponse(response_code=200, body=[]),
+                          DBPagination(limit=0, offset=0, count=0, page=1))
+        )
+        request = _make_request(
+            query_params={"_tag": "runtime:dev"},
+            match_info={"flow_id": "TestFlow"},
+        )
+
+        await run_api.get_all_runs.__wrapped__.__wrapped__(run_api, request)
+
+        call_args = run_api._async_table.find_records.call_args
+        conditions = call_args.kwargs.get("conditions", call_args[1].get("conditions"))
+
+        tag_condition = [c for c in conditions if "?&" in c][0]
+        assert "tags||system_tags" in tag_condition
+
+
+class TestFlowTagFiltering:
+    @pytest.fixture
+    def flow_api(self):
+        app = MagicMock()
+        app.router = MagicMock()
+        app.router.add_route = MagicMock()
+        with patch("services.metadata_service.api.flow.AsyncPostgresDB"):
+            api = FlowApi(app)
+        api._async_table = MagicMock()
+        return api
+
+    async def test_no_tag_param_returns_all_flows(self, flow_api):
+        records = [_flow_record("FlowA"), _flow_record("FlowB")]
+        flow_api._async_table.get_all_flows = AsyncMock(
+            return_value=DBResponse(response_code=200, body=records)
+        )
+        request = _make_request()
+
+        result = await flow_api.get_all_flows.__wrapped__.__wrapped__(flow_api, request)
+
+        flow_api._async_table.get_all_flows.assert_awaited_once()
+        assert result.response_code == 200
+        assert len(result.body) == 2
+
+    async def test_single_tag_filters_flows(self, flow_api):
+        records = [_flow_record("FlowA", tags=["team:ml"])]
+        flow_api._async_table.find_records = AsyncMock(
+            return_value=(DBResponse(response_code=200, body=records),
+                          DBPagination(limit=0, offset=0, count=1, page=1))
+        )
+        request = _make_request(query_params={"_tag": "team:ml"})
+
+        result = await flow_api.get_all_flows.__wrapped__.__wrapped__(flow_api, request)
+
+        flow_api._async_table.find_records.assert_awaited_once()
+        call_args = flow_api._async_table.find_records.call_args
+        conditions = call_args.kwargs.get("conditions", call_args[1].get("conditions"))
+        values = call_args.kwargs.get("values", call_args[1].get("values"))
+
+        assert any("?&" in c for c in conditions)
+        assert "team:ml" in values
+        assert result.response_code == 200
+
+    async def test_multiple_tags_filters_flows(self, flow_api):
+        flow_api._async_table.find_records = AsyncMock(
+            return_value=(DBResponse(response_code=200, body=[]),
+                          DBPagination(limit=0, offset=0, count=0, page=1))
+        )
+        request = _make_request(query_params={"_tag": ["team:ml", "env:prod"]})
+
+        result = await flow_api.get_all_flows.__wrapped__.__wrapped__(flow_api, request)
+
+        call_args = flow_api._async_table.find_records.call_args
+        values = call_args.kwargs.get("values", call_args[1].get("values"))
+
+        assert "team:ml" in values
+        assert "env:prod" in values
+
+    async def test_no_matching_flows_returns_empty(self, flow_api):
+        flow_api._async_table.find_records = AsyncMock(
+            return_value=(DBResponse(response_code=200, body=[]),
+                          DBPagination(limit=0, offset=0, count=0, page=1))
+        )
+        request = _make_request(query_params={"_tag": "nonexistent"})
+
+        result = await flow_api.get_all_flows.__wrapped__.__wrapped__(flow_api, request)
+
+        assert result.response_code == 200
+        assert result.body == []

--- a/services/metadata_service/tests/unit_tests/tag_filtering_test.py
+++ b/services/metadata_service/tests/unit_tests/tag_filtering_test.py
@@ -96,11 +96,11 @@ class TestTagConditionsUtility:
         conditions, values = tag_conditions(query)
         assert values == ["user:alice@corp", "runtime:dev-v2.1"]
 
-    def test_coalesce_null_safety(self):
+    def test_uses_combined_tags_expression(self):
         query = CIMultiDictProxy(CIMultiDict({"_tags": "sometag"}))
         conditions, _ = tag_conditions(query)
-        assert "COALESCE(tags, '[]'::jsonb)" in conditions[0]
-        assert "COALESCE(system_tags, '[]'::jsonb)" in conditions[0]
+        assert "tags||system_tags" in conditions[0]
+        assert "?&" in conditions[0]
 
 
 class TestRunTagFiltering:

--- a/services/migration_service/migration_files/20260315000000_add_flows_gin_tags_index.sql
+++ b/services/migration_service/migration_files/20260315000000_add_flows_gin_tags_index.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query';
+
+CREATE INDEX IF NOT EXISTS flows_v3_idx_gin_tags_combined ON flows_v3 USING gin ((tags || system_tags));
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+
+DROP INDEX IF EXISTS flows_v3_idx_gin_tags_combined;
+
+-- +goose StatementEnd


### PR DESCRIPTION
## Summary

- Add `_tags` query parameter to `GET /flows` and `GET /flows/{flow_id}/runs` for server-side tag filtering
- Tags filtered at the SQL layer using the JSONB `?&` operator on `tags||system_tags`, matching the UI backend and the existing GIN index expression
- GIN index migration for `flows_v3` (runs_v3 already has one from migration `20210202145952`)
- Pulled the SQL condition building into a shared `tag_conditions()` helper in utils.py

## Usage

```
GET /flows?_tags=env:prod
GET /flows?_tags=env:prod,team:ml
GET /flows/{flow_id}/runs?_tags=runtime:dev
GET /flows/{flow_id}/runs?_tags=env:prod,user:alice
```

Multiple comma-separated tags use AND logic (all must match). Omitting `_tags` preserves original behavior.

## Changes

- `services/metadata_service/api/utils.py` - new `tag_conditions()` utility
- `services/metadata_service/api/run.py` - `get_all_runs` calls `tag_conditions()` when `_tags` is present
- `services/metadata_service/api/flow.py` - `get_all_flows` same pattern
- `services/migration_service/migration_files/20260315000000_add_flows_gin_tags_index.sql` - GIN index on `flows_v3 (tags || system_tags)`
- `services/metadata_service/tests/unit_tests/tag_filtering_test.py` - 16 unit tests
- `services/metadata_service/tests/integration_tests/tag_filtering_test.py` - 8 integration tests

## Why not steps/tasks/artifacts/metadata?

Those endpoints are always scoped to a single run via path params. Their tag columns are stale snapshots from creation time, and read APIs overwrite them with the parent run's tags via `apply_run_tags_to_db_response`. Filtering would match all-or-nothing, which is pointless.

## Test plan

- [ ] Unit tests pass (`pytest -m unit_tests`)
- [ ] Integration tests pass against Postgres (`pytest -m integration_tests`)
- [ ] `GET /flows/{flow_id}/runs` without `_tags` returns same results as before
- [ ] `GET /flows/{flow_id}/runs?_tags=sometag` returns only matching runs
- [ ] Comma-separated `_tags=a,b` applies AND logic

Relates to saikonen/metaflow-service#3