### PR TITLE
Simplify dev Docker setup with single multi-target Dockerfile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,37 @@
+# Build goose, pinned to same version as production
+FROM golang:1.18.9-buster AS goose
+RUN go install github.com/pressly/goose/v3/cmd/goose@v3.5.3
+
+# Shared base for all dev services
+FROM python:3.7 AS base
+ADD services /root/services
+ADD setup.py setup.cfg /root/
+WORKDIR /root
+RUN pip install --editable .
+
+# --- targets ---
+
+FROM base AS metadata
+CMD ["metadata_service"]
+
+FROM base AS migration
+COPY --from=goose /go/bin/goose /usr/local/bin/
+ADD run_goose.py /root/
+CMD ["migration_service"]
+
+FROM base AS ui
+ARG UI_ENABLED="1"
+ARG UI_VERSION="v1.2.5"
+ENV UI_ENABLED=$UI_ENABLED
+ENV UI_VERSION=$UI_VERSION
+RUN apt-get update && apt-get install -y --no-install-recommends unzip \
+    && rm -rf /var/lib/apt/lists/*
+RUN /root/services/ui_backend_service/download_ui.sh
+CMD ["ui_backend_service"]
+
+FROM python:3.7 AS test
+COPY --from=goose /go/bin/goose /usr/local/bin/
+RUN pip install tox
+COPY . /app
+WORKDIR /app
+CMD ["/app/wait-for-postgres.sh", "tox"]

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -3,7 +3,8 @@ services:
   ui_backend:
     build:
       context: .
-      dockerfile: Dockerfile.ui_service
+      dockerfile: Dockerfile.dev
+      target: ui
       args:
         UI_ENABLED: 1
     ports:
@@ -53,7 +54,8 @@ services:
   metadata:
     build:
       context: .
-      dockerfile: Dockerfile.metadata_service
+      dockerfile: Dockerfile.dev
+      target: metadata
     ports:
       - "${MF_METADATA_PORT:-8080}:${MF_METADATA_PORT:-8080}"
     volumes:
@@ -70,10 +72,11 @@ services:
     depends_on:
       - migration
   migration:
-    command: ["/opt/latest/bin/python3", "/root/run_goose.py"]
+    command: ["python3", "/root/run_goose.py"]
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev
+      target: migration
     volumes:
       - ./services:/root/services
     environment:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,7 +4,8 @@ services:
     container_name: service_test
     build:
       context: .
-      dockerfile: Dockerfile.service.test
+      dockerfile: Dockerfile.dev
+      target: test
     volumes:
       - .:/app
     environment:


### PR DESCRIPTION
Consolidates the four separate dev/test Dockerfiles into one `Dockerfile.dev` using multi-stage build targets.

## What changed

- New `Dockerfile.dev` with targets: `metadata`, `migration`, `ui`, `test`
- `docker-compose.development.yml` and `docker-compose.test.yml` now reference `Dockerfile.dev` with the appropriate `target:` instead of separate Dockerfiles
- Goose pinned to v3.5.3 in dev, matching production (was v2 via `go get -u` on golang:1.16.3)
- Python version consistent across all targets (3.7)

## Why

The existing dev Dockerfiles (`Dockerfile.metadata_service`, `Dockerfile.migration_service`, `Dockerfile.ui_service`, `Dockerfile.service.test`) are nearly identical - same base image, same pip install, different CMD. Having four copies means version drift (e.g. ui_service used python:3.7.13 while others used 3.7) and goose version mismatch between dev (v2) and prod (v3.5.3).

The old Dockerfiles are left in place for now since the production `docker-compose.yml` still references some of them. Removing them can be a follow-up once production is confirmed to only use the main `Dockerfile`.

## How it works

```
# Same commands as before
docker-compose -f docker-compose.development.yml up
docker-compose -f docker-compose.test.yml up
```

The shared `base` stage installs all services once. Each target adds only what it needs on top (goose for migration, UI download for ui_backend, tox for tests). Volume mounts for hot-reload are unchanged.

Addresses #2.