### PR TITLE
fix: return 400 on numeric ID overflow instead of Postgres 500

### DIFF
--- a/services/data/db_utils.py
+++ b/services/data/db_utils.py
@@ -11,6 +11,15 @@ DBResponse = collections.namedtuple("DBResponse", "response_code body")
 
 DBPagination = collections.namedtuple("DBPagination", "limit offset count page")
 
+# Postgres integer type limits
+PG_INT4_MAX = 2147483647
+PG_INT8_MAX = 9223372036854775807
+
+
+class IdOverflowError(ValueError):
+    """Raised when a numeric ID exceeds Postgres integer range."""
+    pass
+
 
 def aiopg_exception_handling(exception):
     err_msg = str(exception)
@@ -62,12 +71,22 @@ def new_heartbeat_ts():
 
 def translate_run_key(v: str):
     value = str(v)
-    return "run_number" if value.isnumeric() else "run_id", value
+    if value.isnumeric():
+        if int(value) > PG_INT4_MAX:
+            raise IdOverflowError(
+                "run_number %s is out of range for type integer" % value)
+        return "run_number", value
+    return "run_id", value
 
 
 def translate_task_key(v: str):
     value = str(v)
-    return "task_id" if value.isnumeric() else "task_name", value
+    if value.isnumeric():
+        if int(value) > PG_INT8_MAX:
+            raise IdOverflowError(
+                "task_id %s is out of range for type bigint" % value)
+        return "task_id", value
+    return "task_name", value
 
 
 def get_exposed_run_id(run_number, run_id):

--- a/services/metadata_service/api/utils.py
+++ b/services/metadata_service/api/utils.py
@@ -6,6 +6,7 @@ import collections
 from aiohttp import web
 from multidict import MultiDict
 
+from services.data.db_utils import IdOverflowError
 from services.utils import get_traceback_str
 
 version = pkg_resources.require("metadata_service")[0].version
@@ -59,6 +60,8 @@ def handle_exceptions(func):
     async def wrapper(*args, **kwargs):
         try:
             return await func(*args, **kwargs)
+        except IdOverflowError as err:
+            return ServiceResponse(400, {"error": str(err)})
         except Exception as err:
             return http_500(str(err))
 

--- a/services/metadata_service/tests/unit_tests/id_overflow_test.py
+++ b/services/metadata_service/tests/unit_tests/id_overflow_test.py
@@ -1,0 +1,59 @@
+import pytest
+from services.data.db_utils import (
+    translate_run_key,
+    translate_task_key,
+    IdOverflowError,
+    PG_INT4_MAX,
+    PG_INT8_MAX,
+)
+
+
+class TestTranslateRunKey:
+
+    def test_numeric_run_number_within_range(self):
+        col, val = translate_run_key("12345")
+        assert col == "run_number"
+        assert val == "12345"
+
+    def test_max_valid_run_number(self):
+        col, val = translate_run_key(str(PG_INT4_MAX))
+        assert col == "run_number"
+
+    def test_overflow_run_number_raises(self):
+        with pytest.raises(IdOverflowError):
+            translate_run_key(str(PG_INT4_MAX + 1))
+
+    def test_epoch_style_run_number_raises(self):
+        # this is the actual failure case from issue #324 / #1922
+        with pytest.raises(IdOverflowError):
+            translate_run_key("1721143286111471")
+
+    def test_string_run_id_passes(self):
+        col, val = translate_run_key("abc-123")
+        assert col == "run_id"
+        assert val == "abc-123"
+
+    def test_string_run_id_with_numbers_passes(self):
+        # not purely numeric, so treated as run_id
+        col, val = translate_run_key("run-42")
+        assert col == "run_id"
+
+
+class TestTranslateTaskKey:
+
+    def test_numeric_task_id_within_range(self):
+        col, val = translate_task_key("999")
+        assert col == "task_id"
+        assert val == "999"
+
+    def test_max_valid_task_id(self):
+        col, val = translate_task_key(str(PG_INT8_MAX))
+        assert col == "task_id"
+
+    def test_overflow_task_id_raises(self):
+        with pytest.raises(IdOverflowError):
+            translate_task_key(str(PG_INT8_MAX + 1))
+
+    def test_string_task_name_passes(self):
+        col, val = translate_task_key("my-task")
+        assert col == "task_name"


### PR DESCRIPTION
Epoch-based run numbers from local metadata providers (e.g. `1721143286111471`) overflow the Postgres `int4` range when they hit `translate_run_key` and cause a raw Postgres error that surfaces as a 500. This has been open as Netflix/metaflow-service#324 since 2022.

## What changed

`translate_run_key` and `translate_task_key` in `services/data/db_utils.py` now check numeric values against Postgres integer limits before returning. If the value overflows, they raise `IdOverflowError` (a `ValueError` subclass).

The existing `handle_exceptions` decorator in `services/metadata_service/api/utils.py` catches `IdOverflowError` and returns a 400 with a clear error message instead of letting the value reach Postgres and blow up as a 500.

## Why this approach

The fix is at the chokepoint -- every endpoint that takes a `run_number` or `task_id` goes through `translate_run_key` / `translate_task_key`. No individual endpoint handlers need modification. The `handle_exceptions` decorator already wraps every handler, so the new exception type slots in between the existing `HTTPClientError` (400-level) and generic `Exception` (500) catches.

## Tests

10 unit tests covering: valid range, boundary values, overflow, epoch-style IDs, and string ID passthrough. All pass locally.

```
$ python -m pytest services/metadata_service/tests/unit_tests/id_overflow_test.py -v
10 passed in 0.03s
```

Addresses Netflix/metaflow-service#324.